### PR TITLE
fix(ci): pin buildkit version

### DIFF
--- a/.github/workflows/build-container.yml
+++ b/.github/workflows/build-container.yml
@@ -55,6 +55,9 @@ jobs:
       -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+        with:
+          driver-opts: |
+            image=moby/buildkit:v0.10.6
 
       -
         name: Login to Container Registry


### PR DESCRIPTION
GitHub Action runners have recently shown regressions when pushing images to different registries after release of Docker's Moby BuildKit 0.11.0 last week.

For now we are pinning the BuildKit version to a known working version, until upstream is resolved.