### PR TITLE
The last two characters of the key were cut off. Most likely stems fr…

### DIFF
--- a/shell/src/dapps/o-passport/atoms/AccountCard.svelte
+++ b/shell/src/dapps/o-passport/atoms/AccountCard.svelte
@@ -12,7 +12,7 @@ const toggle = () => (isOpen = !isOpen);
 let seedphrase =
   sessionStorage.getItem("circlesKey") && sessionStorage.getItem("circlesKey") != "0x123"
     ? bip39.entropyToMnemonic(
-        sessionStorage.getItem("circlesKey").substring(2, sessionStorage.getItem("circlesKey").length - 2)
+        sessionStorage.getItem("circlesKey").substring(2, sessionStorage.getItem("circlesKey").length)
       )
     : "<no private key>";
 </script>


### PR DESCRIPTION
…om 'substr' -> 'substring' change some commits ago.