### PR TITLE
refresh the transaction list only after the new element is loaded

### DIFF
--- a/shell/src/shared/molecules/DappFrame.svelte
+++ b/shell/src/shared/molecules/DappFrame.svelte
@@ -337,8 +337,9 @@ function setNav(navArgs: GenerateNavManifestArgs) {
 
 function handleNotificationEvent(event: NotificationEvent) {
   if (event.type == EventType.CrcMinting || event.type == EventType.CrcHubTransfer) {
-    myTransactions.findSingleItemFallback([event.type], event.transaction_hash);
-    myTransactions.refresh(true);
+    myTransactions.findSingleItemFallback([event.type], event.transaction_hash).then((_) => {
+        myTransactions.refresh(true);
+    });
     assetBalances.update();
   } else if (event.type == EventType.CrcTrust) {
     contacts.findBySafeAddress(event.to, true);

--- a/shell/src/shared/stores/myTransactions.ts
+++ b/shell/src/shared/stores/myTransactions.ts
@@ -39,7 +39,7 @@ export class MyTransactions extends PagedEventQuery {
       pagination: {
         order: SortOrder.Desc,
         limit: 1,
-        continueAt: new Date().toJSON(),
+        continueAt: new Date('2100-01-01').toJSON(),
       },
       filter: <ProfileEventFilter>{
         transactionHash: primaryKey,


### PR DESCRIPTION
await 'findSingleItemFallback' before proceeding to update the list